### PR TITLE
Fix #87: add support for non-translated presentations

### DIFF
--- a/godot-3-presentation/presentation/Slides.gd
+++ b/godot-3-presentation/presentation/Slides.gd
@@ -79,6 +79,10 @@ func display(slide_index : int) -> void:
 
 
 func update_translations():
+	var translations = ProjectSettings.get_setting("locale/translations")
+	if not translations or translations.size() == 0:
+		return
+
 	for node in get_tree().get_nodes_in_group("translate"):
 		var node_uid = get_translation_uid(node)
 		var translatable_properties = node.get_translation_data()


### PR DESCRIPTION
When updating translations, the code check if there is locale translations in project settings.
If not, we skip the translation of the properties.